### PR TITLE
Fix: loginRequired() does not work when false set as user_id

### DIFF
--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -518,7 +518,7 @@ BaseFacebook.prototype.getUserFromAvailableData = function(callback) {
     }
   }
   else {
-    var user = this.getPersistentData('user_id', 0);
+    var user = this.getPersistentData('user_id', 0) || 0;
     var persistedAccessToken = this.getPersistentData('access_token');
     // use access_token to fetch user id if we have a user access_token, or if
     // the cached access token has changed.


### PR DESCRIPTION
何かしらの原因で (Facebookにログインしていないとか? or something ...) Facebook から返ってきた userId が false だったときに persistent data の user_id に false が入ってしまっている時がありました。

で、その状態で loginRequired() が働かないことがあったので ( facebook.js:64 で  user === 0 で判定してるので、ここで user に false が入っていると next() に進んでしまうため）、getPersistentData の段階で、user_id が false だったら 0 を入れるようにしてみました。
