### PR TITLE
Removed reference to this.request.query.hasOwnProperty

### DIFF
--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -60,7 +60,7 @@ BaseFacebook.prototype.getRequestParam = function(key) {
   if (this.request.query && key in this.request.query) {
     return this.request.query[key];
   }
-  else if (this.request.body && this.request.body.hasOwnProperty(key)) {
+  else if (this.request.body && key in this.request.body) {
     return this.request.body[key];
   }
   else {

--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -57,10 +57,10 @@ BaseFacebook.prototype.getRequestParam = function(key) {
   if (!this.request) {
     return null;
   }
-  if (this.request.query && key in this.request.query) {
+  if (this.request.query && Object.prototype.hasOwnProperty.call(this.request.query, key)) {
     return this.request.query[key];
   }
-  else if (this.request.body && key in this.request.body) {
+  else if (this.request.body && Object.prototype.hasOwnProperty.call(this.request.body, key)) {
     return this.request.body[key];
   }
   else {

--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -57,7 +57,7 @@ BaseFacebook.prototype.getRequestParam = function(key) {
   if (!this.request) {
     return null;
   }
-  if (this.request.query && this.request.query.hasOwnProperty(key)) {
+  if (this.request.query && key in this.request.query) {
     return this.request.query[key];
   }
   else if (this.request.body && this.request.body.hasOwnProperty(key)) {

--- a/test/basefacebook.test.js
+++ b/test/basefacebook.test.js
@@ -387,7 +387,7 @@ module.exports = {
     done = true;
   },
   
-  getCodeWithNullPrototype: function(beforeExit, assert) {
+  getCodeWithNullQueryPrototype: function(beforeExit, assert) {
     var done = false;
     beforeExit(function() { assert.ok(done) });
     var facebook = new TransientFacebook({
@@ -405,6 +405,27 @@ module.exports = {
     assert.equal(code, facebook.getCode(), 'Expect code to be pulled from $_REQUEST[\'code\']');
     done = true;
   },
+  
+  getCodeWithNullBodyPrototype: function(beforeExit, assert) {
+    var done = false;
+    beforeExit(function() { assert.ok(done) });
+    var facebook = new TransientFacebook({
+      appId: config.appId,
+      secret: config.secret,
+      request: {
+        body: Object.create(null),
+        query: Object.create(null)
+      }
+    });
+
+    facebook.establishCSRFTokenState();
+
+    var code = facebook.request.body.code = 'dummy';
+    facebook.request.query.state = facebook.getPersistentData('state');
+    assert.equal(code, facebook.getCode(), 'Expect code to be pulled from $_REQUEST[\'code\']');
+    done = true;
+  },
+  
 
   getUserFromSignedRequest: function(beforeExit, assert) {
     var done = false;

--- a/test/basefacebook.test.js
+++ b/test/basefacebook.test.js
@@ -386,6 +386,25 @@ module.exports = {
     assert.equal(facebook.getCode(), false, 'Expect getCode to fail, CSRF state not sent back.');
     done = true;
   },
+  
+  getCodeWithNullPrototype: function(beforeExit, assert) {
+    var done = false;
+    beforeExit(function() { assert.ok(done) });
+    var facebook = new TransientFacebook({
+      appId: config.appId,
+      secret: config.secret,
+      request: {
+        query: Object.create(null)
+      }
+    });
+
+    facebook.establishCSRFTokenState();
+
+    var code = facebook.request.query.code = 'dummy';
+    facebook.request.query.state = facebook.getPersistentData('state');
+    assert.equal(code, facebook.getCode(), 'Expect code to be pulled from $_REQUEST[\'code\']');
+    done = true;
+  },
 
   getUserFromSignedRequest: function(beforeExit, assert) {
     var done = false;


### PR DESCRIPTION
qs recently removed hasOwnProperty from the prototype of returned parsed query objects (discussion here: https://github.com/visionmedia/node-querystring/issues/61 ), causing facebook-node-sdk to constantly fail. This change removes the reference to hasOwnProperty, fixing the bug.
