### PR TITLE
Update Header Redirect to Javascript Redirect for Facebook Login

### DIFF
--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -71,7 +71,7 @@ Facebook.loginRequired = function(config) {
               next = null;
               return;
             }
-            res.redirect(loginUrl);
+            res.send("<script> top.location.href='"+loginUrl+"'</script>");
             next = null;
           }
           else {

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -71,7 +71,7 @@ Facebook.loginRequired = function(config) {
               next = null;
               return;
             }
-            res.send("<script> top.location.href='"+loginUrl+"'</script>");
+            res.send("<script>top.location.href='"+loginUrl+"'</script>");
             next = null;
           }
           else {


### PR DESCRIPTION
the header redirect do not work under iframe, as a result login redirect will not work for the app on facebook.com. I updated the redirect from header to javascript in order to support app on facebook.com
