### PR TITLE
Handle compressed responses from Graph API

### DIFF
--- a/lib/requestutil.js
+++ b/lib/requestutil.js
@@ -1,4 +1,6 @@
 
+var StringDecoder = require('string_decoder').StringDecoder;
+var zlib = require('zlib');
 var assert = require('assert');
 var querystring = require('querystring');
 var Multipart = require('./multipart');
@@ -180,7 +182,6 @@ FacebookApiRequest.prototype.afterResponse = function(res) {
   assert.equal(this.responseBody, null);
 
   this.res = res;
-  this.res.setEncoding('utf8');
   this.responseBody = [];
   this.res.on('data', this.selfBoundDataHandler);
   this.res.on('error', this.selfBoundDataErrorHandler);
@@ -206,9 +207,26 @@ FacebookApiRequest.prototype.handleEnd = function() {
   assert.notEqual(this.responseBody, null);
   assert.notEqual(this.callback, null);
 
+  var self = this;
+  var decoder = new StringDecoder('utf8');
+
   try {
     this.detachDataAndEndAndErrorHandlers();
-    this.callback(null, this.responseBody.join(''));
+
+    switch(this.res.headers['content-encoding']) {
+      case 'gzip':
+        zlib.gunzip(Buffer.concat(this.responseBody), function (err, data) {
+          self.callback(err, decoder.write(data));
+        });
+        break;
+      case 'deflate':
+        zlib.inflate(Buffer.concat(this.responseBody), function (err, data) {
+          self.callback(err, decoder.write(data));
+        });
+      default:
+        this.res.setEncoding('utf8');
+        this.callback(null, decoder.write(this.responseBody.join('')));
+    }
   }
   catch (err) {
     this.callback(err, null);


### PR DESCRIPTION
This solves the issue where compressed responses are unexpectedly returned from Graph API.
