### PR TITLE
Fixed require to remove __dirname for browserify compatibility.

### DIFF
--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-var BaseFacebook = require(__dirname + '/basefacebook.js');
+var BaseFacebook = require('./basefacebook.js');
 
 function Facebook(config) {
   this.hasSession = !!(config.request && config.request.session);


### PR DESCRIPTION
`require()` with `__dirname` causes problems with browserify.
Browserify is used by https://github.com/jaws-framework/JAWS for deployment to AWS Lambda.
