### PR TITLE
fix(): basefacebook.getAccessTokenFromCode() removed hasOwnProperty

### DIFF
--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -1041,7 +1041,7 @@ BaseFacebook.prototype.getAccessTokenFromCode = function getAccessTokenFromCode(
         }
         else {
           var responseParams = querystring.parse(accessTokenResponse);
-          if (!responseParams.hasOwnProperty('access_token')) {
+          if (!responseParams['access_token']) {
             return false;
           }
           else {

--- a/lib/basefacebook.js
+++ b/lib/basefacebook.js
@@ -78,7 +78,7 @@ BaseFacebook.prototype.getCookie = function(key) {
 };
 
 BaseFacebook.prototype.hasCookie = function(key) {
-  return this.request && this.request.cookies && this.request.cookies.hasOwnProperty(key);
+  return this.request && this.request.cookies && Object.prototype.hasOwnProperty.call(this.request.cookies, key);
 };
 
 BaseFacebook.prototype.sentHeaders = function() {


### PR DESCRIPTION
…fter

querystring.parse now returns an empty Object(null) causing errors when calling hasOwnProperty.